### PR TITLE
Backport to 1.16.5

### DIFF
--- a/.github/workflows/gradle-jdk8.yml
+++ b/.github/workflows/gradle-jdk8.yml
@@ -1,4 +1,4 @@
-name: Java CI with Gradle (OpenJDK 16)
+name: Java CI with Gradle (OpenJDK 8)
 
 on: [push]
 
@@ -9,10 +9,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Set up JDK 16
+    - name: Set up JDK 8
       uses: actions/setup-java@v2
       with:
-        java-version: '16'
+        java-version: '8'
         distribution: 'temurin'
 
     - name: Grant execute permission for gradlew
@@ -24,5 +24,5 @@ jobs:
     - name: Upload artifact
       uses: actions/upload-artifact@v2.2.3
       with:
-          name: jdk16
+          name: jdk8
           path: build/libs/*.jar

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ group = 'org.jedi' // http://maven.apache.org/guides/mini/guide-naming-conventio
 archivesBaseName = 'jedi'
 
 // Mojang ships Java 16 to end users in 1.17+ instead of Java 8 in 1.16 or lower, so your mod should target Java 16.
-java.toolchain.languageVersion = JavaLanguageVersion.of(16)
+java.toolchain.languageVersion = JavaLanguageVersion.of(8)
 
 println('Java: ' + System.getProperty('java.version') + ' JVM: ' + System.getProperty('java.vm.version') + '(' + System.getProperty('java.vendor') + ') Arch: ' + System.getProperty('os.arch'))
 minecraft {
@@ -37,7 +37,7 @@ minecraft {
     //
     // Use non-default mappings at your own risk. They may not always work.
     // Simply re-run your setup task after changing the mappings to update your workspace.
-    mappings channel: 'official', version: '1.17.1'
+    mappings channel: 'official', version: '1.16.5'
 
     // Default run configurations.
     // These can be tweaked, removed, or duplicated as needed.
@@ -131,10 +131,10 @@ repositories {
 }
 
 dependencies {
-    minecraft 'net.minecraftforge:forge:1.17.1-37.1.1'
+    minecraft 'net.minecraftforge:forge:1.16.5-36.2.20'
 
     library('org.javacord:javacord:3.3.2')
-    library('org.apache.logging.log4j:log4j-api:2.17.0')
+    library('org.apache.logging.log4j:log4j-api:2.17.1')
 }
 
 jar {

--- a/src/main/java/org/jedi/DiscordMessageFormatter.java
+++ b/src/main/java/org/jedi/DiscordMessageFormatter.java
@@ -1,13 +1,12 @@
 package org.jedi;
 
-import net.minecraft.ChatFormatting;
-import net.minecraft.network.chat.ClickEvent;
-import net.minecraft.network.chat.Component;
-import net.minecraft.network.chat.HoverEvent;
-import net.minecraft.network.chat.MutableComponent;
-import net.minecraft.network.chat.Style;
-import net.minecraft.network.chat.TextColor;
-import net.minecraft.network.chat.TextComponent;
+import net.minecraft.util.text.TextFormatting;
+import net.minecraft.util.text.event.ClickEvent;
+import net.minecraft.util.text.IFormattableTextComponent;
+import net.minecraft.util.text.event.HoverEvent;
+import net.minecraft.util.text.Style;
+import net.minecraft.util.text.Color;
+import net.minecraft.util.text.StringTextComponent;
 import org.apache.commons.io.FileUtils;
 import org.javacord.api.entity.message.Message;
 import org.javacord.api.entity.message.MessageAttachment;
@@ -22,23 +21,23 @@ public final class DiscordMessageFormatter {
         this.replyingToText = replyingToText;
     }
 
-    public Component format(Message message) {
-        final TextComponent header = new TextComponent("<@");
+    public IFormattableTextComponent format(Message message) {
+        final StringTextComponent header = new StringTextComponent("<@");
         header.append(this.formatAuthorName(message));
         header.append("> ");
 
         final MultilineBuilder builder = new MultilineBuilder(header);
 
         message.getReferencedMessage().ifPresent(parentMessage -> {
-            final MutableComponent replyingTo = new TextComponent(this.replyingToText + " @")
-                    .withStyle(ChatFormatting.GRAY, ChatFormatting.ITALIC)
+            final IFormattableTextComponent replyingTo = new StringTextComponent(this.replyingToText + " @")
+                    .withStyle(TextFormatting.GRAY, TextFormatting.ITALIC)
                     .append(this.formatAuthorName(parentMessage));
             builder.appendLine(replyingTo);
         });
 
         final String[] lines = message.getReadableContent().split("\n");
         for (String line : lines) {
-            builder.appendLine(new TextComponent(line));
+            builder.appendLine(new StringTextComponent(line));
         }
 
         for (MessageAttachment attachment : message.getAttachments()) {
@@ -48,26 +47,26 @@ public final class DiscordMessageFormatter {
         return builder.build();
     }
 
-    private Component formatAuthorName(Message message) {
-        final TextColor color = this.getAuthorColor(message);
-        final TextComponent discriminatedName = new TextComponent(message.getAuthor().getDiscriminatedName());
+    private IFormattableTextComponent formatAuthorName(Message message) {
+        final Color color = this.getAuthorColor(message);
+        final StringTextComponent discriminatedName = new StringTextComponent(message.getAuthor().getDiscriminatedName());
 
-        return new TextComponent(message.getAuthor().getDisplayName())
+        return new StringTextComponent(message.getAuthor().getDisplayName())
                 .withStyle(Style.EMPTY
                         .withColor(color)
                         .withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, discriminatedName))
                 );
     }
 
-    private MutableComponent formatAttachment(MessageAttachment attachment) {
+    private IFormattableTextComponent formatAttachment(MessageAttachment attachment) {
         final String url = attachment.getUrl().toString();
         final Style attachmentStyle = Style.EMPTY
-                .withColor(ChatFormatting.BLUE).withUnderlined(true)
+                .withColor(TextFormatting.BLUE).withUnderlined(true)
                 .withClickEvent(new ClickEvent(ClickEvent.Action.OPEN_URL, url))
-                .withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new TextComponent(url).withStyle(ChatFormatting.BLUE, ChatFormatting.UNDERLINE)));
+                .withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new StringTextComponent(url).withStyle(TextFormatting.BLUE, TextFormatting.UNDERLINE)));
 
         final String description = this.getAttachmentDescription(attachment);
-        return new TextComponent(description).withStyle(attachmentStyle);
+        return new StringTextComponent(description).withStyle(attachmentStyle);
     }
 
     private String getAttachmentDescription(MessageAttachment attachment) {
@@ -83,28 +82,28 @@ public final class DiscordMessageFormatter {
         }
     }
 
-    private TextColor getAuthorColor(Message message) {
+    private Color getAuthorColor(Message message) {
         return message.getAuthor().getRoleColor()
-                .map(value -> TextColor.fromRgb(value.getRGB() & 0xFFFFFF))
-                .orElseGet(() -> TextColor.fromLegacyFormat(ChatFormatting.WHITE));
+                .map(value -> Color.fromRgb(value.getRGB() & 0xFFFFFF))
+                .orElseGet(() -> Color.fromLegacyFormat(TextFormatting.WHITE));
     }
 
     private static final class MultilineBuilder {
-        private static final MutableComponent NEW_LINE = new TextComponent("\n | ").withStyle(ChatFormatting.GRAY);
+        private static final IFormattableTextComponent NEW_LINE = new StringTextComponent("\n | ").withStyle(TextFormatting.GRAY);
 
-        private final MutableComponent header;
-        private final List<MutableComponent> lines = new ArrayList<>();
+        private final IFormattableTextComponent header;
+        private final List<IFormattableTextComponent> lines = new ArrayList<>();
 
-        public MultilineBuilder(MutableComponent header) {
+        public MultilineBuilder(IFormattableTextComponent header) {
             this.header = header;
         }
 
-        public void appendLine(MutableComponent line) {
+        public void appendLine(IFormattableTextComponent line) {
             this.lines.add(line);
         }
 
-        public Component build() {
-            MutableComponent result = this.header;
+        public IFormattableTextComponent build() {
+            IFormattableTextComponent result = this.header;
             for (int i = 0; i < this.lines.size(); i++) {
                 if (i > 0) result.append(NEW_LINE);
                 result.append(this.lines.get(i));

--- a/src/main/java/org/jedi/DiscordWebhooks.java
+++ b/src/main/java/org/jedi/DiscordWebhooks.java
@@ -50,6 +50,6 @@ public final class DiscordWebhooks {
             futures.add(pending.thenCompose(message::send));
         }
 
-        return CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new));
+        return CompletableFuture.allOf(futures.toArray(new CompletableFuture[] {}));
     }
 }

--- a/src/main/java/org/jedi/JustEnoughDiscordIntegrationMod.java
+++ b/src/main/java/org/jedi/JustEnoughDiscordIntegrationMod.java
@@ -1,12 +1,12 @@
 package org.jedi;
 
-import net.minecraft.ChatFormatting;
-import net.minecraft.Util;
+import net.minecraft.util.text.TextFormatting;
+import net.minecraft.util.Util;
 import net.minecraft.advancements.Advancement;
-import net.minecraft.network.chat.ChatType;
-import net.minecraft.network.chat.Component;
-import net.minecraft.world.entity.EntityType;
-import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.util.text.ChatType;
+import net.minecraft.util.text.IFormattableTextComponent;
+import net.minecraft.entity.EntityType;
+import net.minecraft.entity.LivingEntity;
 import net.minecraftforge.common.ForgeConfigSpec;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.ServerChatEvent;
@@ -15,18 +15,18 @@ import net.minecraftforge.event.entity.player.AdvancementEvent;
 import net.minecraftforge.event.entity.player.PlayerEvent;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
-import net.minecraftforge.fml.IExtensionPoint;
+import net.minecraftforge.fml.ExtensionPoint;
 import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.config.ModConfig;
-import net.minecraftforge.fml.event.config.ModConfigEvent;
+import net.minecraftforge.fml.config.ModConfig.ModConfigEvent;
 import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
-import net.minecraftforge.fmllegacy.network.FMLNetworkConstants;
-import net.minecraftforge.fmllegacy.server.ServerLifecycleHooks;
-import net.minecraftforge.fmlserverevents.FMLServerStartingEvent;
-import net.minecraftforge.fmlserverevents.FMLServerStoppedEvent;
-import net.minecraftforge.fmlserverevents.FMLServerStoppingEvent;
+import net.minecraftforge.fml.network.FMLNetworkConstants;
+import net.minecraftforge.fml.server.ServerLifecycleHooks;
+import net.minecraftforge.fml.event.server.FMLServerStartingEvent;
+import net.minecraftforge.fml.event.server.FMLServerStoppedEvent;
+import net.minecraftforge.fml.event.server.FMLServerStoppingEvent;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.javacord.api.DiscordApi;
@@ -38,9 +38,11 @@ import org.javacord.api.entity.message.mention.AllowedMentionsBuilder;
 import org.javacord.api.event.message.MessageCreateEvent;
 import org.javacord.api.listener.channel.server.text.WebhooksUpdateListener;
 import org.javacord.api.listener.message.MessageCreateListener;
+import org.apache.commons.lang3.tuple.Pair;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -86,8 +88,8 @@ public class JustEnoughDiscordIntegrationMod {
         ModLoadingContext.get().registerConfig(ModConfig.Type.SERVER, SERVER_CONFIG);
         MinecraftForge.EVENT_BUS.register(this);
 
-        ModLoadingContext.get().registerExtensionPoint(IExtensionPoint.DisplayTest.class, () -> {
-            return new IExtensionPoint.DisplayTest(
+        ModLoadingContext.get().registerExtensionPoint(ExtensionPoint.DISPLAYTEST, () -> {
+            return Pair.of (
                     () -> FMLNetworkConstants.IGNORESERVERONLY,
                     (a, b) -> true
             );
@@ -102,10 +104,10 @@ public class JustEnoughDiscordIntegrationMod {
                 .define("bot_token", "");
 
         webhookEntries = builder.comment(" List of webhook URLs to post to from the game")
-                .defineList("webhook_urls", List.of(""), entry -> true);
+                .defineList("webhook_urls", Arrays.asList(""), entry -> true);
 
         readChannels = builder.comment(" List of IDs of discord channels to listen to")
-                .defineList("read_channels", List.of(), entry -> true);
+                .defineList("read_channels", Arrays.asList(), entry -> true);
 
         builder.push("Translations");
 
@@ -224,7 +226,7 @@ public class JustEnoughDiscordIntegrationMod {
             if (!message.getAuthor().isRegularUser()) return;
             if (!readChannels.get().contains(event.getChannel().getId())) return;
 
-            Component chatMessage = messageFormatter.format(message);
+            IFormattableTextComponent chatMessage = messageFormatter.format(message);
             ServerLifecycleHooks.getCurrentServer().getPlayerList().broadcastMessage(chatMessage, ChatType.CHAT, Util.NIL_UUID);
         }
     }
@@ -249,6 +251,6 @@ public class JustEnoughDiscordIntegrationMod {
     }
 
     private static String strip(final String original) {
-        return ChatFormatting.stripFormatting(original);
+        return TextFormatting.stripFormatting(original);
     }
 }

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -1,5 +1,5 @@
 modLoader="javafml"
-loaderVersion="[37,)"
+loaderVersion="[36,)"
 license="MPLv2"
 issueTrackerURL="https://github.com/Cojomax99/JustEnoughDiscordIntegration/issues"
 


### PR DESCRIPTION
**NB: obviously this shouldn't merge to this base branch, please create a 1.16.5 branch for these changes :)**

- Adds support for JEDI to run on 1.16.5, with fixes for the 1.17.1 mappings and Java 16 specific features this mod utilises.

Tested on a whitelisted server - happy to provide login details privately to save you the trouble of creating your own to test on.